### PR TITLE
Change isSameEmployee to check employee id instead of name

### DIFF
--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -85,7 +85,7 @@ public class Employee {
         }
 
         return otherEmployee != null
-                && otherEmployee.getName().equals(getName());
+                && otherEmployee.getId().equals(getId());
     }
 
     /**

--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -76,7 +76,7 @@ public class Employee {
     }
 
     /**
-     * Returns true if both employees have the same name.
+     * Returns true if both employees have the same employee id.
      * This defines a weaker notion of equality between two employees.
      */
     public boolean isSameEmployee(Employee otherEmployee) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -32,8 +32,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_POSITION_AMY = "Manager";
     public static final String VALID_POSITION_BOB = "Junior Manager";
-    public static final String VALID_ID_AMY = "EID1234-5678";
-    public static final String VALID_ID_BOB = "EID5678-1234";
+    public static final String VALID_ID_AMY = "EID8765-1234";
+    public static final String VALID_ID_BOB = "EID4030-1020";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";

--- a/src/test/java/seedu/address/model/employee/EmployeeTest.java
+++ b/src/test/java/seedu/address/model/employee/EmployeeTest.java
@@ -34,24 +34,15 @@ public class EmployeeTest {
         // null -> returns false
         assertFalse(ALICE.isSameEmployee(null));
 
-        // same name, all other attributes different -> returns true
-        Employee editedAlice = new EmployeeBuilder(ALICE).withPosition(VALID_POSITION_BOB).withId(VALID_ID_BOB)
+        // same id, all other attributes different -> returns true
+        Employee editedAlice = new EmployeeBuilder(ALICE).withName(VALID_NAME_BOB).withPosition(VALID_POSITION_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withDepartments(VALID_DEPARTMENT_HUSBAND).build();
         assertTrue(ALICE.isSameEmployee(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new EmployeeBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different id, all other attributes same -> returns false
+        editedAlice = new EmployeeBuilder(ALICE).withId(VALID_ID_BOB).build();
         assertFalse(ALICE.isSameEmployee(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Employee editedBob = new EmployeeBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameEmployee(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new EmployeeBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameEmployee(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EmployeeBuilder.java
+++ b/src/test/java/seedu/address/testutil/EmployeeBuilder.java
@@ -20,7 +20,7 @@ public class EmployeeBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_POSITION = "software engineer";
-    public static final String DEFAULT_ID = "EID1234-5678";
+    public static final String DEFAULT_ID = "EID0102-0304";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_SALARY = "$12,000";


### PR DESCRIPTION
Changed isSameEmployee to check employee id instead of name (if employee's have the same employee id then they are considered duplicates since all employees should have unique ids)
